### PR TITLE
RK-10649 - Update node version to 14.18.1 to fix cert problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM node:8.9.4
-
-RUN apt-get install ca-certificates -y
-RUN update-ca-certificates -f
+FROM node:14.18.1
 
 ARG GIT_COMMIT=unspecified
 ENV ROOKOUT_COMMIT=$GIT_COMMIT


### PR DESCRIPTION
Another ricochet from the LetsEncrypt X3 deprecation.

Logs from the staging sandbox app:
![image](https://user-images.githubusercontent.com/1862068/138591706-150a986b-f913-40c2-99c2-a19f724075e3.png)

so same symptom from previous scenarios: accessing https://staging.control.rookout.com/ works well from my machine and the certificate seems to be fine, it just the app that fails to verify it.